### PR TITLE
Dumping LLVM IR in favour of a visual representation of the Module

### DIFF
--- a/tools/tolerator/main.cpp
+++ b/tools/tolerator/main.cpp
@@ -104,6 +104,9 @@ static cl::list<string> libraries{"l",
                                   cl::value_desc{"library prefix"},
                                   cl::cat{toleratorCategory}};
 
+static cl::opt<bool> emitIR{"emit-llvm",
+                            cl::desc{"Emit LLVM IR"},
+                            cl::cat{toleratorCategory}};
 
 static void
 compile(Module& m, StringRef outputPath) {
@@ -298,6 +301,10 @@ instrument(Module& m, AnalysisType analysisType) {
   pm.add(new tolerator::Tolerator(analysisType));
   pm.add(createVerifierPass());
   pm.run(m);
+
+  if (emitIR) {
+    m.print(llvm::errs(), nullptr);
+  }
 
   generateBinary(m, outFile);
   saveModule(m, outFile + ".tolerator.bc");


### PR DESCRIPTION
Dumping the IR is helping me a lot, maybe it will help others ;)